### PR TITLE
Auto update dev-01deg_jra55_iaf to use access-test/pr56-1

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,8 +1,12 @@
-name: a cool config
+manifest:
+  reproduce:
+    exe: false
 modules:
   load:
-  - access-test/2025.01.000
+  - access-test/pr56-1
   - something/2021.02.003
   use:
   - /g/data/vk83/modules
   - /g/data/vk83/software/modules
+  - /g/data/vk83/prerelease/modules
+name: a cool config


### PR DESCRIPTION
Auto-generated PR to update dev-01deg_jra55_iaf to use access-test/pr56-1 from ACCESS-NRI/ACCESS-TEST#56, see https://github.com/ACCESS-NRI/ACCESS-TEST/actions/runs/20321466929